### PR TITLE
Set time range in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
       ],
       "minimumReleaseAge": "7 days",
       "schedule": [
-        "* 11 * * 1"
+        "* 11-20 * * 1"
       ]
     }
   ]


### PR DESCRIPTION
renovate hasn't opened a PR in the past 2 weeks since we added the cron scheduler