### PR TITLE
Meta

### DIFF
--- a/astro/src/components/BaseHead.astro
+++ b/astro/src/components/BaseHead.astro
@@ -1,19 +1,23 @@
 ---
 // Import the global.css file here so that it is included on
 // all pages through the use of the <BaseHead /> component.
-import "@/styles/global.scss";
-import type { ImageMetadata } from "astro";
-import { SITE_TITLE } from "@/consts";
+import '@/styles/global.scss';
+import type { ImageMetadata } from 'astro';
+import { SITE_TITLE, SITE_DESCRIPTION } from '@/consts';
 
 interface Props {
-  title: string;
-  description: string;
+  title?: string;
+  description?: string;
   image?: ImageMetadata;
 }
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
-const { title, description, image } = Astro.props;
+const {
+  title = SITE_TITLE,
+  description = SITE_DESCRIPTION,
+  image,
+} = Astro.props;
 ---
 
 <!-- Global Metadata -->
@@ -24,8 +28,8 @@ const { title, description, image } = Astro.props;
 <link
   rel="alternate"
   type="application/rss+xml"
-  title={SITE_TITLE}
-  href={new URL("rss.xml", Astro.site)}
+  title={title}
+  href={new URL('rss.xml', Astro.site)}
 />
 <meta name="generator" content={Astro.generator} />
 

--- a/astro/src/components/layouts/default.astro
+++ b/astro/src/components/layouts/default.astro
@@ -11,7 +11,6 @@
   The unnamed slot is for content going inside <main>
 */
 
-import { SITE_DESCRIPTION, SITE_TITLE } from '@/consts';
 import { sitemap } from '@/content/sitemap';
 import BaseHead from '@/components/BaseHead.astro';
 
@@ -30,7 +29,7 @@ const { title } = Astro.props;
 <html lang="en">
   <head>
     <slot name="head">
-      <BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
+      <BaseHead />
     </slot>
   </head>
   <body>

--- a/astro/src/content.config.ts
+++ b/astro/src/content.config.ts
@@ -18,7 +18,7 @@ const blog = defineCollection({
   schema: () =>
     z.object({
       title: z.string(),
-      description: z.string().nullish(),
+      description: z.coerce.string(),
       date: z.string(),
       updatedDate: z.string().optional(),
       // Transform string to Date object

--- a/astro/src/pages/blog/[slug].astro
+++ b/astro/src/pages/blog/[slug].astro
@@ -23,11 +23,6 @@ const { Content } = await render(post);
     slot="head"
     title={post.data.title}
     description={post.data.description}
-    let's
-    fix
-    this
-    bloody
-    issue
   />
 
   <Article {...post.data}>

--- a/astro/src/pages/blog/[slug].astro
+++ b/astro/src/pages/blog/[slug].astro
@@ -23,6 +23,11 @@ const { Content } = await render(post);
     slot="head"
     title={post.data.title}
     description={post.data.description}
+    let's
+    fix
+    this
+    bloody
+    issue
   />
 
   <Article {...post.data}>

--- a/astro/src/pages/blog/[slug].astro
+++ b/astro/src/pages/blog/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import { type CollectionEntry, getCollection, render } from 'astro:content';
 
+import BaseHead from '@/components/BaseHead.astro';
 import Article from '@/components/article/article.astro';
 import Layout from '@/components/layouts/default.astro';
 
@@ -18,6 +19,12 @@ const { Content } = await render(post);
 ---
 
 <Layout title={post.data.title}>
+  <BaseHead
+    slot="head"
+    title={post.data.title}
+    description={post.data.description}
+  />
+
   <Article {...post.data}>
     <Content />
   </Article>


### PR DESCRIPTION
fixes #12 

Update `BaseHead` component to accept title and description as a prop.

Supposed to add a favicon and title images for opengraph, but this blog doesn't really use images so we'll skip this step for now.